### PR TITLE
Add possibility to manage encryption configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The `jerakia` class supports the following optional parameters
 * `install_package`: If set to false, don't manage the package (default: true)
 * `config_dir`: Location of the configuration directory
 * `config_replace`: If set to false, will not overwrite the config after creation
+* `config_mode`: Config file mode (default: 0600)
 * `policy_dir`: Location of the policy directory
 * `manage_config_dir`: Create/manage the config dir (default: true)
 * `manage_plugin_dir`: Create/manage the plugin dir (default: true)
@@ -69,6 +70,7 @@ The `jerakia` class supports the following optional parameters
 * `enable_schemas`: Enable or disable schemas by setting true or false
 * `schema_opts`: A hash containing schema override options
 * `plugin_opts`: A hash of options to be passed to plugins
+* `encryption_opts`: A hash of options for encryption
 
 ### Examples:
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,9 +42,6 @@ class jerakia::config {
     ensure  => file,
     content => template('jerakia/jerakia.yaml.erb'),
     replace => $::jerakia::config_replace,
+    mode    => $::jerakia::config_mode,
   }
-
-
-
 }
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,7 @@ class jerakia (
   $install_package           = $::jerakia::params::install_package,
   $config_dir                = $::jerakia::params::config_dir,
   $config_replace            = $::jerakia::params::config_replace,
+  $config_mode               = $::jerakia::params::config_mode,
   $policy_dir                = $::jerakia::params::policy_dir,
   $manage_config_dir         = $::jerakia::params::manage_config_dir,
   $manage_plugin_dir         = $::jerakia::params::manage_plugin_dir,
@@ -60,6 +61,7 @@ class jerakia (
   $enable_schemas            = undef,
   $schema_opts               = {},
   $plugin_opts               = {},
+  $encryption_opts           = {},
   ) inherits jerakia::params {
 
   class { '::jerakia::package': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class jerakia::params  {
 
   $config_dir       = '/etc/jerakia'
   $config_replace   = true
+  $config_mode      = '0600'
   $plugin_dir       = "${config_dir}/lib"
   $policy_dir       = "${config_dir}/policy.d"
   $logfile          = '/var/log/jerakia/jerakia.log'
@@ -29,7 +30,5 @@ class jerakia::params  {
   $logfile_owner = 'puppet'
   $logfile_group = 'puppet'
   $logfile_mode  = '0644'
-
-
 
 }

--- a/templates/jerakia.yaml.erb
+++ b/templates/jerakia.yaml.erb
@@ -25,8 +25,6 @@ schema:
 <% end -%>
 <% end -%>
 
-
-
 <% unless scope['::jerakia::plugin_opts'].empty? -%>
 # Plugin options
 plugins:
@@ -38,4 +36,10 @@ plugins:
 <% end -%>
 <% end -%>
 
-
+<% unless scope['::jerakia::encryption_opts'].empty? -%>
+# Encryption options
+encryption:
+<% scope['::jerakia::encryption_opts'].each do |key, val| -%>
+  <%= key %>: <%= val %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
- New optional parameter jerakia::encryption_opts
  - a hash of key value pairs which are placed in jerakia config
    under 'encryption:'

- New optional parameter jerakia::config_mode (default 0600)
  - sets the file mode of jerakia config
  (The current file mode for jerakia allows other users to read the secret encryption parameters.)

- Update the README